### PR TITLE
Use concurrent futures to reduce blocking IO

### DIFF
--- a/hirefire/procs/__init__.py
+++ b/hirefire/procs/__init__.py
@@ -82,7 +82,7 @@ def native_dump_procs(procs):
     with ThreadPoolExecutor() as executor:
         # Execute all procs in parallel to avoid blocking IO
         # especially celery which needs to open a transport to AMQP.
-        return executor.map(_run, procs.items())
+        return list(executor.map(_run, procs.items()))
 
 
 def dump_procs(procs):

--- a/hirefire/procs/__init__.py
+++ b/hirefire/procs/__init__.py
@@ -82,7 +82,7 @@ def native_dump_procs(procs):
     with ThreadPoolExecutor as executor:
         # Execute all procs in parallel to avoid blocking IO
         # especially celery which needs to open a transport to AMQP.
-        return executor.map(_run, rocs.items()))
+        return executor.map(_run, rocs.items())
 
 
 def dump_procs(procs):

--- a/hirefire/procs/__init__.py
+++ b/hirefire/procs/__init__.py
@@ -79,7 +79,7 @@ def native_dump_procs(procs):
             'quantity': quantity or 0,
         }
         
-    with ThreadPoolExecutor as executor:
+    with ThreadPoolExecutor() as executor:
         # Execute all procs in parallel to avoid blocking IO
         # especially celery which needs to open a transport to AMQP.
         return executor.map(_run, rocs.items())

--- a/hirefire/procs/__init__.py
+++ b/hirefire/procs/__init__.py
@@ -82,7 +82,7 @@ def native_dump_procs(procs):
     with ThreadPoolExecutor() as executor:
         # Execute all procs in parallel to avoid blocking IO
         # especially celery which needs to open a transport to AMQP.
-        return executor.map(_run, rocs.items())
+        return executor.map(_run, procs.items())
 
 
 def dump_procs(procs):

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,10 @@ setup(
     author='Jannis Leidel',
     author_email='jannis@leidel.info',
     packages=find_packages(),
-    install_requires=['six'],
+    install_requires=[
+        'six',
+        'futures; python_version == "2.7"',
+    ],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Web Environment',


### PR DESCRIPTION
Especially the queue inspection can be currently very slow,
because a transport to the message broker needs to be opened
and messages are exchanged. Especially in multi queue setup
these operations should happen in a concurrent manner.