### PR TITLE
Fix #42 -- Aquire and dispose broker connection per request

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,12 @@ cache:
 - pip
 services:
 - rabbitmq
-install: pip install -Ur requirements.txt
-script: coverage run --source=hirefire -m pytest
+- redis-server
+env:
+  - TOXENV = redis
+  - TOXENV = rabbitmq
+install: pip install -U tox codecov
+script: tox -e "$TOXENV"
 branches:
   only:
   - master

--- a/tests/contrib/django/testapp/__init__.py
+++ b/tests/contrib/django/testapp/__init__.py
@@ -1,0 +1,17 @@
+from __future__ import absolute_import, unicode_literals
+import os
+from celery import Celery
+
+# set the default Django settings module for the 'celery' program.
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'proj.settings')
+
+app = Celery('proj')
+
+# Using a string here means the worker doesn't have to serialize
+# the configuration object to child processes.
+# - namespace='CELERY' means all celery-related configuration keys
+#   should have a `CELERY_` prefix.
+app.config_from_object('django.conf:settings', namespace='CELERY')
+
+# Load task modules from all registered Django app configs.
+app.autodiscover_tasks()

--- a/tests/contrib/django/testapp/procs.py
+++ b/tests/contrib/django/testapp/procs.py
@@ -4,4 +4,4 @@ from hirefire.procs.celery import CeleryProc
 class WorkerProc(CeleryProc):
     name = 'worker'
     queues = ['celery']
-    inspect_statuses = []
+    inspect_statuses = ['active', 'reserved', 'scheduled']

--- a/tests/contrib/django/testapp/settings.py
+++ b/tests/contrib/django/testapp/settings.py
@@ -125,3 +125,8 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/2.1/howto/static-files/
 
 STATIC_URL = '/static/'
+
+
+# Celery
+
+CELERY_BROKER_URL = os.getenv('CELERY_BROKER_URL', 'amqp://')

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,14 @@
+[[tox]
+envlist = redis,rabbitmq
+
+[testenv]
+deps = -rrequirements.txt
+commands = coverage run --append --source=hirefire -m pytest
+
+[testenv:redis]
+setenv =
+    CELERY_BROKER_URL = amqp://
+
+[testenv:rabbitmq]
+setenv =
+    CELERY_BROKER_URL = redis://


### PR DESCRIPTION
Acquire the connection each time `quantity` is called instead of
only once during app loading in Django.
Dispose old connection after usage.