### PR TITLE
ProcSerializer should inherit from object, otherwise super call from …

### DIFF
--- a/hirefire/procs/__init__.py
+++ b/hirefire/procs/__init__.py
@@ -64,7 +64,7 @@ def load_procs(*procs):
     return loaded_procs
 
 
-class ProcSerializer:
+class ProcSerializer(object):
     """
     Callable that transforms procs to dictionaries.
 


### PR DESCRIPTION
…DjangoProcSerializer will fail