### PR TITLE
Make RQ proc counting more efficient / correct, and warn on double queue usage

### DIFF
--- a/hirefire/procs/rq.py
+++ b/hirefire/procs/rq.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 from rq import Queue, Worker
+from rq.registry import StartedJobRegistry
 from rq.exceptions import NoSuchJobError
 
 from . import ClientProc
@@ -56,18 +57,9 @@ class RQProc(ClientProc):
         """
         count = 0
 
+        # Total count should be what's queued plus the started jobs.
         for queue in self.clients:
-            # first add the count of all scheduled jobs
-            count += queue.count
-            # then add all workers which are currently working on jobs of
-            # this Proc's queues
-            for worker in Worker.all(connection=self.connection):
-                try:
-                    if (queue.name in worker.queue_names() and
-                            worker.get_current_job() is not None):
-                        count += 1
-                except NoSuchJobError:
-                    # the jobs have vanished for some reason from Redis
-                    # weren't able to be fetched from the worker
-                    continue
+            registry = StartedJobRegistry(queue.name, queue.connection)
+            count += (queue.count + len(registry))
+
         return count

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 -e .
 celery
+fakeredis
 hotqueue
 huey
 queues

--- a/tests/contrib/django/test_rq_proc.py
+++ b/tests/contrib/django/test_rq_proc.py
@@ -1,0 +1,63 @@
+from unittest import mock
+
+from fakeredis import FakeStrictRedis
+from rq.queue import Queue
+from rq.registry import StartedJobRegistry
+
+import hirefire
+from hirefire.procs import load_procs, loaded_procs
+from tests.contrib.django.testapp.rq_test_procs import AnotherWorkerProc
+
+
+class TestRQProc:
+
+	# TODO: add proper proc unloading as part of test startup and teardown.
+
+	def test_can_count_queues_properly(self):
+		try:
+			loaded_procs.clear()
+			# Put some jobs on the queue
+			self._add_jobs_to_queue('high', 2)
+			self._add_jobs_to_queue('bottom', 4)
+
+			# Now fake a job being active for one of them
+			for idx, queue_name in enumerate(['high', 'bottom']):
+				queue = Queue(queue_name, connection=FakeStrictRedis())
+				registry = StartedJobRegistry(queue_name, queue.connection)
+				# Passing in a negative score is important here, otherwise the job will be recognized as expired
+				registry.connection.zadd(registry.key, -1, 'job_id_{}'.format(idx))
+
+			# Load the HF procs
+			procs = load_procs(*(
+				'tests.contrib.django.testapp.rq_test_procs.WorkerProc',
+				'tests.contrib.django.testapp.rq_test_procs.AnotherWorkerProc'
+			))
+
+			# Total should be all queued + 1 active for each
+			assert sum([proc.quantity() for proc_name, proc in procs.items()]) == 8
+		finally:
+			loaded_procs.clear()
+
+	def test_warns_when_queues_are_multi_assigned(self):
+		try:
+			loaded_procs.clear()
+			# Force a queue of the same name from one proc onto the other proc.
+			AnotherWorkerProc.queues.append('high')
+			with mock.patch.object(hirefire.procs, 'logger') as patched_logger:
+				load_procs(*(
+					'tests.contrib.django.testapp.rq_test_procs.WorkerProc',
+					'tests.contrib.django.testapp.rq_test_procs.AnotherWorkerProc'
+				))
+				patched_logger.warning.assert_called()
+		finally:
+			AnotherWorkerProc.queues.pop(2)
+			loaded_procs.clear()
+
+	def _add_jobs_to_queue(self, queue_name, num):
+		queue = Queue(queue_name, connection=FakeStrictRedis())
+		for _ in range(num):
+			queue.enqueue(self._dummy_func)
+
+	@classmethod
+	def _dummy_func(cls):
+		pass

--- a/tests/contrib/django/testapp/rq_test_procs.py
+++ b/tests/contrib/django/testapp/rq_test_procs.py
@@ -1,0 +1,15 @@
+from hirefire.procs.rq import RQProc
+from fakeredis import FakeStrictRedis
+from rq import Queue
+
+
+class WorkerProc(RQProc):
+    name = 'worker'
+    queues = ['high', 'low']
+    connection = FakeStrictRedis()
+
+
+class AnotherWorkerProc(RQProc):
+    name = 'double_dipping_worker'
+    queues = ['top', 'bottom']
+    connection = FakeStrictRedis()


### PR DESCRIPTION
As has been noted in another issue (https://github.com/ryanhiebert/hirefire/issues/12), HireFire over Python RQ has some performance issues. Digging around a bit, there seems to be some misunderstanding about how RQ works under the hood as implied by the implementation of the job counting function. HireFire is fairly inefficient at computing the counts, and also appears to do it wrongly. The original implementation:
```python
        def quantity(self, **kwargs):
            count = 0
            for queue in self.clients:
                count += queue.count
                for worker in Worker.all(connection=self.connection):
                    try:
                        if (queue.name in worker.queue_names() and worker.get_current_job() is not None):
                            count += 1
                    except NoSuchJobError:
                        continue
            return count
```
Just so I'm sure we're all on the same page, it's my understanding that in RQ's implementation, a "queue" is merely a namespace (a key in redis that holds job ids) for grouping jobs with a label (there is some priority calculation, but that's irrelevant here). A "worker" is a process that pulls jobs off of the (prioritized) queues it has been made aware of by queue name args given to the rqworker command. "Pulling jobs" means it takes a job id out of the id set in the redis ZSET, looks up the data for the job by its key in redis based on that job id, and gets to work. What the code quoted above does is call `worker#get_current_job` several times, one for each queue the rqworker process is aware of via those command line args. So what happens is that count for a given proc in HireFire gets incremented by 1 for the same job multiple times: one for every queue the worker is directed to consume from. Debugging through the library code while this computation is taking place and seeing the same job (by job id) returned repeatedly by `worker.get_current_job()` confirms it.

The new implementation I'm submitting mimicks what RQ does on the Django RQ admin page: it leverages the started job registry, which is a ZSET that holds the ongoing jobs. The iteration is also done over the queues, not the workers inside them. Overall, it's 2 redis calls per queue (one ZCARD for the startup registry's ZSET size, and one LLEN for the queue's job count). Speedup on production for me has been dramatic.

Also, this misunderstanding appears to entail a corollary risk more generally in HireFire: the quantity summation will result in double counting across procs if multiple procs declare the same queue name. That probably isn't common practice, but it's probably a good idea to warn the user if it's occurring.
