### PR TITLE
Warn when user has declared the same queue on multiple procs

### DIFF
--- a/tests/contrib/django/test_rq_proc.py
+++ b/tests/contrib/django/test_rq_proc.py
@@ -1,8 +1,12 @@
+from unittest import mock
+
 from fakeredis import FakeStrictRedis
 from rq.queue import Queue
 from rq.registry import StartedJobRegistry
 
+import hirefire
 from hirefire.procs import load_procs, loaded_procs
+from tests.contrib.django.testapp.rq_test_procs import AnotherWorkerProc
 
 
 class TestRQProc:
@@ -32,6 +36,21 @@ class TestRQProc:
 			# Total should be all queued + 1 active for each
 			assert sum([proc.quantity() for proc_name, proc in procs.items()]) == 8
 		finally:
+			loaded_procs.clear()
+
+	def test_warns_when_queues_are_multi_assigned(self):
+		try:
+			loaded_procs.clear()
+			# Force a queue of the same name from one proc onto the other proc.
+			AnotherWorkerProc.queues.append('high')
+			with mock.patch.object(hirefire.procs, 'logger') as patched_logger:
+				load_procs(*(
+					'tests.contrib.django.testapp.rq_test_procs.WorkerProc',
+					'tests.contrib.django.testapp.rq_test_procs.AnotherWorkerProc'
+				))
+				patched_logger.warning.assert_called()
+		finally:
+			AnotherWorkerProc.queues.pop(2)
 			loaded_procs.clear()
 
 	def _add_jobs_to_queue(self, queue_name, num):


### PR DESCRIPTION
Though it might be perfectly allowable, reusing the same queue cannot be relied upon to give accurate job counts given certain backends.