### PR TITLE
CeleryProc creates a lot of idle channels

### DIFF
--- a/hirefire/procs/celery.py
+++ b/hirefire/procs/celery.py
@@ -260,17 +260,17 @@ class CeleryProc(Proc):
         Returns the aggregated number of tasks of the proc queues.
         """
         with self.app.connection_or_acquire() as connection:
-            channel = connection.channel()
+            with connection.channel() as channel:
 
-            # Redis
-            if hasattr(channel, '_size'):
-                return sum(self._get_redis_task_count(channel, queue) for queue in self.queues)
+                # Redis
+                if hasattr(channel, '_size'):
+                    return sum(self._get_redis_task_count(channel, queue) for queue in self.queues)
 
-            # RabbitMQ
-            count = sum(self._get_rabbitmq_task_count(channel, queue) for queue in self.queues)
-            if cache is not None and self.inspect_statuses:
-                count += self.inspect_count(cache)
-            return count
+                # RabbitMQ
+                count = sum(self._get_rabbitmq_task_count(channel, queue) for queue in self.queues)
+                if cache is not None and self.inspect_statuses:
+                    count += self.inspect_count(cache)
+                return count
 
     def inspect_count(self, cache):
         """Use Celery's inspect() methods to see tasks on workers."""


### PR DESCRIPTION
## Reasoning

After installing hirefire middleware + `CeleryProc` we noticed that number of channels started growing linearly.
![image](https://user-images.githubusercontent.com/36153295/53998041-b7dcf600-413e-11e9-9515-4ecc5d6a7d7b.png)

It looks like `hirefire.procs.celery.CeleryProc` creates a lot of new channels and leaves them opened because  `connection.channel()` creates new channel on every call.

## What has changed?

* Use channel as a context manager to auto-close it after usage.

## How to test it and expected results?

* Install middleware and and configure simple celery `CeleryProc`
* refresh `http://localhost:8000/hirefire/development/info` few times
* look at server logs (it should not create new channels)

Before:
![image](https://user-images.githubusercontent.com/36153295/53997795-e5756f80-413d-11e9-93ed-2c8f381a9208.png)

After:
![image](https://user-images.githubusercontent.com/36153295/53997780-d7275380-413d-11e9-86f5-e1f97eadd07e.png)
