### PR TITLE
Rework Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,41 @@
-sudo: false
+dist: xenial
 language: python
 python:
-- '3.6'
-cache:
-- pip
-services:
-- rabbitmq
-- redis-server
+  - "3.6"
+  - "3.7"
 env:
-  - TOXENV = redis
-  - TOXENV = rabbitmq
+  - TOXENV=redis
+  - TOXENV=rabbitmq
+cache:
+  - pip
+addons:
+  apt:
+    packages:
+      - rabbitmq-server
+services:
+  - redis-server
 install: pip install -U tox codecov
-script: tox -e "$TOXENV"
-branches:
-  only:
-  - master
-  - "/^\\d+(\\.\\d+)*$/"
-matrix:
+script: tox
+after_success: codecov
+
+stages:
+  - test
+  - name: deploy
+    if: tag IS present
+
+jobs:
   fast_finish: true
-after_success:
-- codecov
-deploy:
-  provider: pypi
-  user: ryanhiebert-auto
-  password:
-    secure: bRbLOOfykUfoFbKlVc5Zoe97sTfVvMZU+JdK+hp/hnQQswqjFAHn+hW+r7orPBZUxQDdEDtDR/38d3j19XRgxB2biB6vv18jBKeI/HzAfkZt274IouDgvSNdCQNJ+d8EKR6SGuHIYpfEMwLWyLPQiMk7LcpleQ2VJNb8/74mOas=
-  distributions: sdist bdist_wheel
-  on:
-    tags: true
-    python: 3.6
+  include:
+    - stage: deploy
+      python: 3.7
+      install: true
+      script: true
+      after_success: true
+      deploy:
+        provider: pypi
+        user: ryanhiebert-auto
+      password:
+        secure: bRbLOOfykUfoFbKlVc5Zoe97sTfVvMZU+JdK+hp/hnQQswqjFAHn+hW+r7orPBZUxQDdEDtDR/38d3j19XRgxB2biB6vv18jBKeI/HzAfkZt274IouDgvSNdCQNJ+d8EKR6SGuHIYpfEMwLWyLPQiMk7LcpleQ2VJNb8/74mOas=
+      distributions: sdist bdist_wheel
+      on:
+        all_branches: true


### PR DESCRIPTION
* Use Travis stages to put deployment in its own Job
* Use Xenial dist (16.04), requires using apt for rabbitmq. sudo=False not supported.
* Add Python 3.7 testing.