### PR TITLE
Enforce that the HireFire token is present in the Flask HireFire endpoint.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,9 +74,9 @@ For more help see the Hirefire `documentation`_.
 Configuration
 -------------
 
-The ``hirefire`` Python package currently supports two frameworks:
-Django and Tornado. Implementations for other frameworks are planned but
-haven't been worked on: Flask_, Pyramid_ (PasteDeploy), WSGI_ middleware, ..
+The ``hirefire`` Python package currently supports three frameworks:
+Django, Tornado, and Flask_. Implementations for other frameworks are planned
+but haven't been worked on: Pyramid_ (PasteDeploy), WSGI_ middleware, ..
 
 Feel free to `contribute one`_ if you can't wait.
 
@@ -104,7 +104,7 @@ Define a ``RQProc`` subclass somewhere in your project, e.g.
 See the procs API documentation if you're using another backend. Now follow
 the framework specific guidelines below.
 
-.. _`contribute one`: https://github.com/jezdez/hirefire/
+.. _`contribute one`: https://github.com/ryanhiebert/hirefire/
 .. _flask: http://flask.pocoo.org/
 .. _Pyramid: http://www.pylonsproject.org/
 .. _WSGI: http://www.python.org/dev/peps/pep-3333/

--- a/hirefire/contrib/flask/blueprint.py
+++ b/hirefire/contrib/flask/blueprint.py
@@ -26,8 +26,8 @@ def build_hirefire_blueprint(token, procs):
         """
         return HIREFIRE_FOUND
 
-    @bp.route('/hirefire/<id>/info')
-    def info(id):
+    @bp.route('/hirefire/<secret>/info')
+    def info(secret):
         """
         The heart of the app, returning a JSON ecoded list
         of proc results.

--- a/hirefire/contrib/flask/blueprint.py
+++ b/hirefire/contrib/flask/blueprint.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
+from http import HTTPStatus
 
-from flask import Blueprint, Response
+from flask import abort, Blueprint, Response
 
 from hirefire.procs import load_procs, dump_procs, HIREFIRE_FOUND
 
@@ -32,6 +33,10 @@ def build_hirefire_blueprint(token, procs):
         The heart of the app, returning a JSON ecoded list
         of proc results.
         """
+
+        if secret != token:
+            abort(HTTPStatus.NOT_FOUND)
+
         return Response(dump_procs(loaded_procs), mimetype='application/json')
 
     return bp

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 -e .
 celery
+flask
 redis
 rq
 Django

--- a/tests/contrib/flask/test_blueprint.py
+++ b/tests/contrib/flask/test_blueprint.py
@@ -1,0 +1,42 @@
+"""Tests for the Flask blueprint factory."""
+
+from http import HTTPStatus
+
+import pytest
+
+from flask import Flask
+
+
+@pytest.fixture
+def flask_app():
+    """A Flask application instance."""
+
+    app = Flask(__name__)
+    app.testing = True
+
+    return app
+
+
+@pytest.mark.parametrize(
+    "token, status_code",
+    (("test", HTTPStatus.OK), ("garbage", HTTPStatus.NOT_FOUND))
+)
+def test_hirefire_info(flask_app, monkeypatch, token, status_code):
+    """Enforce the presence of the HireFire token in the info endpoint path."""
+
+    # Patch over load_procs() and dump_procs() so we don't have to worry about
+    # specifying actual Proc subclasses when we construct the test blueprint.
+    monkeypatch.setattr("hirefire.procs.load_procs", lambda *args: args)
+    monkeypatch.setattr("hirefire.procs.dump_procs", lambda arg: {})
+    
+    from hirefire.contrib.flask.blueprint import build_hirefire_blueprint
+
+    # Normally, the second argument would be a list of Proc subclasses. We can
+    # pass a garbage string because we patched over load_procs() and
+    # dump_procs()
+    flask_app.register_blueprint(build_hirefire_blueprint("test", ("proc",)))
+    
+    with flask_app.test_client() as client:
+        response = client.get(f"/hirefire/{token}/info")
+
+    assert response.status_code == status_code


### PR DESCRIPTION
Per the HireFire docs (e.g. [this][0] page), The HireFire info endpoint should be of the form `/hirefire/{HIREFIRE_TOKEN}/info`.

Currently, `hirefire.contrib.flask.blueprint.build_hirefire_blueprint` registers a URL route that matches not just `/hirefire/{HIREFIRE_TOKEN}/info`, but any URL path of the form `/hirefire/{...}/info`. This could be considered a security vulnerability because it is possible to access the HireFire info endpoint without knowing the HireFire token. Practically, however, I think this is just a bug that causes the implementation to be slightly out of sync with the specification.

The changes in this PR enforce that the info endpoint's path is specifically `/hirefire/{HIREFIRE_TOKEN}/info`.

[0]: https://help.hirefire.io/article/52-job-queue-any-programming-language